### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![ClockTST](dev/clock.jpg)
 
-[![Github Releases (by Release)](https://img.shields.io/github/downloads/atom/atom/v0.7.2/total.svg?maxAge=2592000?style=plastic)](https://github.com/Tyxz/-ESO--ingame--Clock---Tamriel-Standard-Time/releases/tag/v0.7.2)
+[![Run on Repl.it](https://repl.it/badge/github/Tyxz/-ESO--ingame--Clock---Tamriel-Standard-Time)](https://repl.it/github/Tyxz/-ESO--ingame--Clock---Tamriel-Standard-Time)
 [![POEditor](https://img.shields.io/badge/POEditor-Help%20Translate-blue.svg?style=flat)](https://poeditor.com/join/project/3ldrMQvCrU)
 [![Website](https://img.shields.io/website-up-down-green-red/http/shields.io.svg?maxAge=2592000)](http://www.esoui.com/downloads/info241-Clock-TamrielStandardTime.html)
 [![Twitter URL](https://img.shields.io/twitter/url/http/shields.io.svg?style=social&maxAge=2592000?style=flat)](https://twitter.com/Tyxzs)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Tyxz/-ESO-ingame-Clock-Tamriel-Standard-Time).